### PR TITLE
Fix pylint CI job in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   python2-tests:
     name: "Python2: PyLint and Pytest"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Hi @MarkSymsCtx!

This is the update commit for the [status-report PR #134](https://github.com/xenserver/status-report/pull/134):
- Fix pylint CI job in GitHub CI